### PR TITLE
update feed metadata to match iTunes guidelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ branches:
   only:
   - gh-pages
   - "/^release-.*/"
+  - "/^test-.*/"
 language: ruby
 rvm: 2.1
-before_script: 
+before_script:
   - bash setup-staging.sh
 script: bundle exec jekyll build
 group: stable
@@ -20,6 +21,5 @@ deploy:
   upload-dir: "$TRAVIS_BRANCH"
   local-dir: _site
   region: "us-west-2"
-  on: 
+  on:
     all_branches: true
-

--- a/feed/index.xml
+++ b/feed/index.xml
@@ -54,6 +54,7 @@ xmlns:rawvoice="http://www.rawvoice.com/rawvoiceRssModule/"
     {% endif %}
 
 
+
     <link>{{ site.url }}{{ ep.url }}</link>
     <comments>{{ site.url }}{{ ep.url }}#comments</comments>
     <pubDate>{{ ep.date | date: "%a, %d %b %Y %T %z" }}</pubDate>

--- a/feed/index.xml
+++ b/feed/index.xml
@@ -11,7 +11,7 @@ xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
 xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
 xmlns:rawvoice="http://www.rawvoice.com/rawvoiceRssModule/"
 >
- 
+
 <channel>
 <title>{{ site.podcast_title }}</title>
 <atom:link href="{{ site.url }}/feed/podcast" rel="self" type="application/rss+xml" />
@@ -46,7 +46,14 @@ xmlns:rawvoice="http://www.rawvoice.com/rawvoiceRssModule/"
 </itunes:category>
 {% for ep in site.posts %}
   <item>
+    {% assign title = ep.title | split: ": " %}
+    {% if title.size > 1 and title.first contains "Episode" %}
+    <title>{{ title | last }}</title>
+    {% else %}
     <title>{{ ep.title }}</title>
+    {% endif %}
+
+
     <link>{{ site.url }}{{ ep.url }}</link>
     <comments>{{ site.url }}{{ ep.url }}#comments</comments>
     <pubDate>{{ ep.date | date: "%a, %d %b %Y %T %z" }}</pubDate>
@@ -58,16 +65,10 @@ xmlns:rawvoice="http://www.rawvoice.com/rawvoiceRssModule/"
     <category><![CDATA[{{ category | cdata_escape }}]]></category>
 {% endfor %}
     <guid isPermaLink="{% if ep.podcast_guid %}false{% else %}true{% endif %}">{{ site.url }}{% if ep.podcast_guid %}/{{ ep.podcast_guid }}{% else %}{{ ep.url }}{% endif %}</guid>
-    <description>
-        <![CDATA[{{ ep.excerpt | strip_html | truncatewords: 50 | expand_urls: site.url | cdata_escape }}]]>
-    </description>
-    <content:encoded>
-        <![CDATA[{{ ep.content | expand_urls: site.url | cdata_escape }}]]>
-    </content:encoded>
 
     <enclosure url="{{ ep.podcast_link }}" length="{{ ep.podcast_length }}" type="audio/mpeg" />
     <itunes:subtitle><![CDATA[{{ ep.excerpt | strip_html | truncatewords: 50 | expand_urls: site.url | cdata_escape }}]]></itunes:subtitle>
-    <itunes:summary><![CDATA[{{ ep.content | expand_urls: site.url | cdata_escape }}]]></itunes:summary>
+    <itunes:summary><![CDATA[{{ ep.content | strip_html | expand_urls: site.url | cdata_escape }}]]></itunes:summary>
     <itunes:author>{{ site.podcast_author }}</itunes:author>
     <itunes:image href="{{ site.url }}{{site.baseurl}}{{ site.podcast_album_art }}" />
     <itunes:explicit>{{ site.podcast_explicit }}</itunes:explicit>


### PR DESCRIPTION
from an e-mail (2/27) from iTunes


Optimize Your Show’s Metadata 

The metadata of your show is your product packaging. It includes all of the details about your show — such as title, author name, description — that potential listeners will see on Apple Podcasts. High-quality metadata can help your show be discovered and grow your audience, as it ultimately determines whether it appears in relevant user searches. 

Conversely, poor-quality podcast metadata may affect new submissions as well as active shows to ensure our platform meets Apple’s quality standards. 

Here are some things to avoid:
Including placeholder text from your hosting provider. For example, descriptions such as “Podcast by [author name],” “New podcast weblog,” “Cover art photo provided by [name],” or “Description goes here.”
Verbatim repetition of the title or author name in the description. For example, “The Very Hungry Tourists by Dr. María Sánchez and John Appleseed.”
Incorporating irrelevant content or spam. For example, show titles like “The Very Hungry Tourists | Travel | Explore | Learn” or author names like “Dr. María Sánchez, coach and travel enthusiast.”
Adding episode numbers in titles. For example, show titles like “The Very Hungry Tourists Episode 01” or episode titles like “01 Broken Heirloom.”
These practices could result in your show being rejected or removed from Apple Podcasts. 

---
**Actions Taken**

* Remove "Episode XX:" from titles in feed `<title>` tag (https://github.com/acannistra/topophilia-website/pull/6/commits/01e571efd27f7797bd5d2500c90ca92f3a54afd7#diff-7a41172475923eed39d92d317b31f684R49)
* `strip_html` from descriptions (https://github.com/acannistra/topophilia-website/pull/6/commits/01e571efd27f7797bd5d2500c90ca92f3a54afd7#diff-7a41172475923eed39d92d317b31f684R71)
* use `<itunes:summary>` tag instead of `<description>` for longform description (*same as above*)
* updated travis to build and stage `test-*` branches (https://github.com/acannistra/topophilia-website/pull/6/commits/acd09f1af8004242398f8ca6ff2f413816cf8b7c#diff-354f30a63fb0907d4ad57269548329e3R6)